### PR TITLE
feat(dsh): add typed built-in Turn host

### DIFF
--- a/docs/integrations/deepseek-harness-connector.md
+++ b/docs/integrations/deepseek-harness-connector.md
@@ -28,8 +28,8 @@ LoopX quota should-run
   the model's final JSON result back into `loopx_turn_result_v0`.
 - A `deepseek-harness` agent type in LoopX onboarding so users can request the
   exact host instead of the generic `other-agent`.
-- Optional dependency `loopx[deepseek-harness]` for the
-  `deepseek-harness-sdk` Python client.
+- Optional dependency `loopx[deepseek-harness]` for the validated
+  `deepseek-harness-sdk==0.1.2a3` Python client.
 
 ## Install
 
@@ -40,14 +40,18 @@ python -m pip install 'loopx[deepseek-harness]'
 ```
 
 The DeepSeek Harness SDK spawns the bundled `dsh-jsonrpc-agent` runtime. It
-inherits normal dsh environment variables such as:
+uses the explicit adapter configuration plus normal provider environment
+variables:
 
 ```text
 DEEPSEEK_API_KEY
 DEEPSEEK_BASE_URL
-DSH_SESSION_ROOT
-DSH_CWD
+DSH_HOME
 ```
+
+The adapter resolves its SDK home in this order: explicit `--dsh-home`, then
+`DSH_HOME`, then `<workspace>/.local/.dsh-sessions`. It passes that path as the
+SDK's `dsh_home` field; the SDK does not implicitly select `~/.dsh`.
 
 Prepare a dsh `cordis.yml` when the default bundled composition is not
 appropriate. See the
@@ -79,14 +83,42 @@ loopx turn run-once \
   --host generic-cli \
   --execution-mode isolated-headless \
   --project "$PWD" \
-  --host-adapter-command-json '["python3", "-m", "loopx.dsh_goal_mode", "--cordis", "/path/to/cordis.yml", "--model", "deepseek-v4-flash"]' \
+  --host-adapter-command-json '["python3", "-m", "loopx.dsh_goal_mode", "--dsh-home", "/path/to/dsh-home", "--cordis", "/path/to/cordis.yml", "--model", "deepseek-v4-flash"]' \
   --validation-command-json '["python3", "/path/to/verify-postcondition.py"]' \
   --execute
 ```
 
-The adapter stores opaque dsh session data under
-`<workspace>/.local/.dsh-sessions/` by default. Override with
-`--session-root <path>` when a different local path is required.
+The adapter uses `<workspace>/.local/.dsh-sessions/` as its workspace-local
+SDK home by default. Override it with `--dsh-home <path>`; the historical
+`--session-root` spelling remains an adapter-command compatibility alias.
+Session persistence itself is owned by the selected dsh composition and is not
+implied by the home-directory name.
+
+## Run One Governed Turn In Process (`--host dsh`)
+
+The built-in host runs the same adapter inside the CLI process:
+
+```bash
+loopx turn run-once \
+  --goal-id <goal-id> \
+  --agent-id deepseek-worker \
+  --host dsh \
+  --execution-mode isolated-headless \
+  --project "$PWD" \
+  --dsh-home /path/to/dsh-home \
+  --dsh-cordis /path/to/cordis.yml \
+  --dsh-model deepseek-v4-flash \
+  --validation-command-json '["python3", "/path/to/verify-postcondition.py"]' \
+  --execute
+```
+
+Unlike the subprocess mode, provider failures reach the Turn journal as typed
+`loopx_turn_host_failure_v0` kinds (including the SDK's exception-free
+`RunResult.finish_reason == "error"` terminal report), so bounded same-Turn
+retry stays available. This mode does not promise cross-turn dsh session
+continuity or an outer wake/timer. See the adapter README for the home and
+classification precedence, plus the hermetic verification smoke
+(`examples/loopx-turn-dsh-builtin-host-e2e-smoke.py`).
 
 ## Boundaries
 
@@ -99,32 +131,41 @@ The adapter stores opaque dsh session data under
   completion. An independent validator is required before LoopX writeback.
 - The dsh Python SDK is an optional dependency. Core LoopX remains runtime
   dependency-free.
+- The adapter derives an owner-local session id, but LoopX does not project or
+  validate a DSH Host Session Binding. This surface therefore does not claim a
+  managed supervisor or cross-process resume guarantee.
 
 ## Hermetic Validation
 
-The repository includes three smokes. The first two do not require the
+The repository includes four validation paths. The first three do not require the
 DeepSeek Harness SDK or a real dsh runtime:
 
 ```bash
 python3 examples/dsh-turn-host-adapter-smoke.py
 python3 examples/loopx-turn-dsh-e2e-smoke.py
+python3 examples/loopx-turn-dsh-builtin-host-e2e-smoke.py
 ```
 
 The first guards adapter translation and result shaping. The second drives the
 full `loopx turn run-once -> adapter -> fake dsh -> validator -> writeback ->
-quota spend -> idempotent replay` chain.
+quota spend -> idempotent replay` chain. The third proves the built-in host's
+success path plus three bounded provider-capacity attempts, retry-budget
+exhaustion without a fourth Host invocation, zero failure spend/writeback, and
+provider-prose non-persistence.
 
-The third uses the real `deepseek-harness-sdk` and the bundled dsh JSON-RPC
+The fourth uses the real `deepseek-harness-sdk` and the bundled dsh JSON-RPC
 runtime. It still avoids a real model call by serving a local mock OpenAI-compatible
 SSE endpoint, so it is hermetic and does not require `DEEPSEEK_API_KEY`:
 
 ```bash
-python3 examples/loopx-turn-dsh-real-e2e-smoke.py
+python3 examples/loopx-turn-dsh-real-e2e-smoke.py --host generic-cli
+python3 examples/loopx-turn-dsh-real-e2e-smoke.py --host dsh
 ```
 
-The real-dsh smoke proves that the adapter can start the actual dsh runtime,
-run one bounded turn through the real JSON-RPC agent loop, parse a typed JSON
-final message, and complete LoopX validation/writeback/quota spend.
+The real-dsh smoke clears ambient DSH home variables and proves that both host
+paths can supply an explicit SDK home, start the actual dsh runtime, run one
+bounded turn through the real JSON-RPC agent loop, parse a typed JSON final
+message, and complete LoopX validation/writeback/quota spend.
 
 ## Related Contracts
 

--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -92,6 +92,9 @@ A DeepSeek Harness adapter lives in the `loopx.dsh_goal_mode` subpackage
 `scripts/dsh_turn_host_adapter.py` launcher still works); it uses
 the optional `deepseek-harness-sdk` Python client to run one bounded dsh session
 and parses the final assistant JSON message into the same typed Turn result.
+Prefer the built-in `loopx turn run-once --host dsh` surface so structured SDK
+terminal failures reach the Turn Journal. The module/subprocess invocation with
+`--host generic-cli` remains the compatibility and rollback path.
 See [DeepSeek Harness connector](../../integrations/deepseek-harness-connector.md).
 
 ### Five Questions For Any Agent CLI

--- a/examples/host-mode-plan-smoke.py
+++ b/examples/host-mode-plan-smoke.py
@@ -219,14 +219,17 @@ def test_pi_alias_resolves_to_goal_loop_connector() -> None:
 
 
 def test_visible_mode_fails_closed_for_unknown_host_identity() -> None:
-    try:
-        build_workflow_identity_plan("watch_each_turn", host_identity="not-a-host")
-    except HostModePlanError as exc:
-        payload = exc.to_payload()
-    else:
-        raise AssertionError("unknown host identity should fail closed")
-    assert payload["ok"] is False, payload
-    assert payload["field"] == "host_identity", payload
+    for host_identity in ("not-a-host", "dsh"):
+        try:
+            build_workflow_identity_plan("watch_each_turn", host_identity=host_identity)
+        except HostModePlanError as exc:
+            payload = exc.to_payload()
+        else:
+            raise AssertionError(
+                f"unsupported visible host identity {host_identity!r} should fail closed"
+            )
+        assert payload["ok"] is False, payload
+        assert payload["field"] == "host_identity", payload
 
 
 def test_emitted_connector_ids_exist_in_catalog() -> None:

--- a/examples/loopx-turn-dsh-builtin-host-e2e-smoke.py
+++ b/examples/loopx-turn-dsh-builtin-host-e2e-smoke.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""End-to-end qualification for the built-in ``--host dsh`` Turn path.
+
+Reuses the generic-cli e2e fixture but drives ``loopx turn run-once`` with the
+in-process dsh host instead of a subprocess adapter, proving two legs without
+a DeepSeek Harness SDK, network access, or credentials:
+
+1. success: planner and scheduler accept the ``dsh`` host, one bounded fake
+   attempt passes independent validation, writeback commits, quota spends
+   exactly once, and a replay stays idempotent;
+2. terminal provider failure: the fake runner returns an SDK-compatible
+   envelope (``finish_reason="error"`` plus a ``turn/end`` reason carrying the
+   provider-specific ``MODEL_AT_CAPACITY`` code), the Turn journal records
+   attempts 1/2/3 with the bounded backoff contract, and an exhausted fourth
+   retry invokes no Host; no failure attempt writes state, spends quota, or
+   persists provider prose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+_BASE_PATH = REPO_ROOT / "examples" / "loopx-turn-dsh-e2e-smoke.py"
+_SPEC = importlib.util.spec_from_file_location("loopx_turn_dsh_e2e_smoke", _BASE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_base = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _base
+_SPEC.loader.exec_module(_base)
+
+
+def _builtin_argv(
+    *,
+    registry: Path,
+    runtime: Path,
+    workspace: Path,
+    runner: Path,
+    turn_instance_id: str,
+    timeout_seconds: float,
+) -> list[str]:
+    return [
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "turn",
+        "run-once",
+        "--goal-id",
+        _base.GOAL_ID,
+        "--agent-id",
+        _base.AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--host",
+        "dsh",
+        "--execution-mode",
+        "isolated-headless",
+        "--project",
+        str(workspace),
+        "--dsh-runner",
+        str(runner),
+        "--validation-command-json",
+        json.dumps(_base._validator_command()),
+        "--validation-failure-kind",
+        "repair_required",
+        "--scan-root",
+        str(registry.parent.parent),
+        "--no-global-sync",
+        "--timeout-seconds",
+        str(timeout_seconds),
+    ]
+
+
+def _write_capacity_runner(root: Path) -> tuple[Path, Path]:
+    outcome: dict[str, Any] = {
+        "final_response": "",
+        "finish_reason": "error",
+        "events": [
+            {
+                "type": "turn/end",
+                "data": {
+                    "reason": {
+                        "kind": "error",
+                        "error": {
+                            "code": "MODEL_AT_CAPACITY",
+                            "status": 503,
+                            "message": "selected model is at capacity",
+                        },
+                    }
+                },
+            }
+        ],
+    }
+    runner = root / "capacity_dsh_runner.py"
+    counter = root / "capacity-dsh-invocations.txt"
+    runner.write_text(
+        "from pathlib import Path\n"
+        f"COUNTER = Path({str(counter)!r})\n"
+        "def run_dsh_turn(**kwargs):\n"
+        "    previous = int(COUNTER.read_text() or '0') if COUNTER.exists() else 0\n"
+        "    COUNTER.write_text(str(previous + 1), encoding='utf-8')\n"
+        f"    return {outcome!r}\n",
+        encoding="utf-8",
+    )
+    return runner, counter
+
+
+def _contains_text(roots: list[Path], needle: str) -> bool:
+    for root in roots:
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if needle in text:
+                return True
+    return False
+
+
+def _success_leg(timeout_seconds: float) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="loopx-turn-dsh-builtin-") as directory:
+        root = Path(directory)
+        _project, runtime, workspace, registry = _base._write_fixture(root)
+        runner = _base._write_fake_dsh_runner(root, workspace)
+        base = _builtin_argv(
+            registry=registry,
+            runtime=runtime,
+            workspace=workspace,
+            runner=runner,
+            turn_instance_id="builtin-turn-1",
+            timeout_seconds=timeout_seconds,
+        )
+        exit_code, payload = _base._run_cli([*base, "--execute"])
+        marker = workspace / _base.MARKER_NAME
+        marker_valid = (
+            marker.is_file()
+            and marker.read_text(encoding="utf-8").strip() == _base.MARKER_VALUE
+        )
+        turn_key = payload.get("resume_turn_key")
+        replay_exit_code, replay = (None, None)
+        if exit_code == 0 and isinstance(turn_key, str):
+            replay_base = list(base)
+            index = replay_base.index("--turn-instance-id")
+            del replay_base[index : index + 2]
+            replay_exit_code, replay = _base._run_cli(
+                [*replay_base, "--resume-turn-key", turn_key, "--execute"]
+            )
+        return {
+            "exit_code": exit_code,
+            "status": payload.get("status"),
+            "result_kind": payload.get("result_kind"),
+            "validation": payload.get("validation"),
+            "effects": payload.get("effects"),
+            "marker_valid": marker_valid,
+            "quota_slot_spend_count": _base._quota_spend_count(runtime),
+            "replay_exit_code": replay_exit_code,
+            "replay_effects": (
+                replay.get("effects") if isinstance(replay, dict) else None
+            ),
+        }
+
+
+def _capacity_leg(timeout_seconds: float) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="loopx-turn-dsh-capacity-") as directory:
+        root = Path(directory)
+        project, runtime, workspace, registry = _base._write_fixture(root)
+        runner, counter = _write_capacity_runner(root)
+        argv = _builtin_argv(
+            registry=registry,
+            runtime=runtime,
+            workspace=workspace,
+            runner=runner,
+            turn_instance_id="builtin-capacity-1",
+            timeout_seconds=timeout_seconds,
+        )
+        initial_exit_code, initial_payload = _base._run_cli([*argv, "--execute"])
+        attempt_payloads = [initial_payload]
+        turn_key = initial_payload.get("resume_turn_key")
+        exhausted_exit_code = None
+        exhausted_payload: dict[str, Any] = {}
+        if isinstance(turn_key, str):
+            retry_argv = list(argv)
+            index = retry_argv.index("--turn-instance-id")
+            del retry_argv[index : index + 2]
+            for _attempt in (2, 3):
+                retry_exit_code, retry_payload = _base._run_cli(
+                    [
+                        *retry_argv,
+                        "--resume-turn-key",
+                        turn_key,
+                        "--retry-failed-turn",
+                        "--execute",
+                    ]
+                )
+                attempt_payloads.append(retry_payload)
+                if retry_exit_code != 1:
+                    break
+            exhausted_exit_code, exhausted_payload = _base._run_cli(
+                [
+                    *retry_argv,
+                    "--resume-turn-key",
+                    turn_key,
+                    "--retry-failed-turn",
+                    "--execute",
+                ]
+            )
+
+        return {
+            "initial_exit_code": initial_exit_code,
+            "initial_result_kind": initial_payload.get("result_kind"),
+            "failure_records": [
+                payload.get("host_failure") for payload in attempt_payloads
+            ],
+            "failure_effects": [
+                payload.get("effects") for payload in attempt_payloads
+            ],
+            "quota_slot_spend_count": _base._quota_spend_count(runtime),
+            "exhausted_exit_code": exhausted_exit_code,
+            "exhausted_effects": exhausted_payload.get("effects"),
+            "exhausted_recovery_decision": exhausted_payload.get(
+                "recovery_decision"
+            ),
+            "host_invocation_count": (
+                int(counter.read_text(encoding="utf-8")) if counter.is_file() else 0
+            ),
+            "raw_provider_prose_persisted": _contains_text(
+                [project, runtime, workspace],
+                "selected model is at capacity",
+            ),
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout-seconds", type=float, default=300.0)
+    args = parser.parse_args()
+
+    success = _success_leg(args.timeout_seconds)
+    capacity = _capacity_leg(args.timeout_seconds)
+    summary = {
+        "schema_version": "loopx_turn_dsh_builtin_host_e2e_v0",
+        "real_dsh_invoked": False,
+        "success_leg": success,
+        "capacity_leg": capacity,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    expected_effects = {
+        "host_invoked": True,
+        "state_written": True,
+        "quota_spent": True,
+        "scheduler_acknowledged": False,
+    }
+    expected_replay_effects = {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    expected_failure_effects = {
+        "host_invoked": True,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    expected_exhausted_effects = {
+        "host_invoked": False,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+    expected_failure_records = [
+        {
+            "schema_version": "loopx_turn_host_failure_v0",
+            "kind": "provider_capacity",
+            "attempt": attempt,
+            "retryable": True,
+            "retry": {
+                "strategy": "same_configuration",
+                "max_attempts": 3,
+                "backoff_seconds": backoff,
+            },
+        }
+        for attempt, backoff in ((1, 30), (2, 60), (3, 120))
+    ]
+    exhausted_decision = capacity["exhausted_recovery_decision"] or {}
+    ok = (
+        success["exit_code"] == 0
+        and success["status"] == "committed"
+        and success["result_kind"] == "validated_progress"
+        and (success["validation"] or {}).get("status") == "passed"
+        and success["effects"] == expected_effects
+        and success["marker_valid"]
+        and success["quota_slot_spend_count"] == 1
+        and success["replay_exit_code"] == 0
+        and success["replay_effects"] == expected_replay_effects
+        and capacity["initial_exit_code"] == 1
+        and capacity["initial_result_kind"] == "host_failure"
+        and capacity["failure_records"] == expected_failure_records
+        and capacity["failure_effects"]
+        == [expected_failure_effects] * len(expected_failure_records)
+        and capacity["quota_slot_spend_count"] == 0
+        and capacity["exhausted_exit_code"] == 1
+        and capacity["exhausted_effects"] == expected_exhausted_effects
+        and exhausted_decision.get("reason") == "host_retry_budget_exhausted"
+        and exhausted_decision.get("reinvoke_host") is False
+        and capacity["host_invocation_count"] == 3
+        and capacity["raw_provider_prose_persisted"] is False
+    )
+    if not ok:
+        raise SystemExit(f"built-in dsh host e2e failed: {summary}")
+    print("built-in dsh host e2e passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/loopx-turn-dsh-real-e2e-smoke.py
+++ b/examples/loopx-turn-dsh-real-e2e-smoke.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Real DeepSeek Harness end-to-end qualification for the LoopX Turn adapter.
+"""Real DeepSeek Harness end-to-end qualification for both LoopX DSH hosts.
 
 This smoke uses the actual ``deepseek-harness-sdk`` and the bundled dsh runtime
 binary. It does not call a real DeepSeek model endpoint: a local mock
 OpenAI-compatible SSE server stands in for the LLM, so the test is hermetic and
 does not require DEEPSEEK_API_KEY. It proves that the adapter can start a real
 dsh JSON-RPC runtime, run one bounded turn, receive a typed JSON final message,
-and let LoopX validate/writeback/spend through the normal Turn chain.
+and let LoopX validate/writeback/spend through the normal Turn chain. The
+smoke clears ambient DSH home variables and supplies one explicit local home,
+so a passing run proves the SDK launch prerequisite is wired by the adapter.
 """
 
 from __future__ import annotations
@@ -171,9 +173,9 @@ def _base_argv(
     registry: Path,
     runtime: Path,
     workspace: Path,
-    session_root: Path,
+    dsh_home: Path,
     cordis: Path,
-    base_url: str,
+    host: str,
     timeout_seconds: float,
 ) -> list[str]:
     host_command = json.dumps(
@@ -182,8 +184,8 @@ def _base_argv(
             str(ADAPTER),
             "--cordis",
             str(cordis),
-            "--session-root",
-            str(session_root),
+            "--dsh-home",
+            str(dsh_home),
             "--request-timeout-seconds",
             "30",
             "--workspace",
@@ -192,7 +194,7 @@ def _base_argv(
             "mock-model",
         ]
     )
-    return [
+    argv = [
         "--registry",
         str(registry),
         "--runtime-root",
@@ -208,23 +210,39 @@ def _base_argv(
         "--turn-instance-id",
         "real-dsh-qualification-turn-1",
         "--host",
-        "generic-cli",
+        host,
         "--execution-mode",
         "isolated-headless",
         "--project",
         str(workspace),
-        "--host-command-json",
-        host_command,
-        "--validation-command-json",
-        json.dumps(_validator_command()),
-        "--validation-failure-kind",
-        "repair_required",
-        "--scan-root",
-        str(registry.parent.parent),
-        "--no-global-sync",
-        "--timeout-seconds",
-        str(timeout_seconds),
     ]
+    if host == "generic-cli":
+        argv.extend(["--host-command-json", host_command])
+    else:
+        argv.extend(
+            [
+                "--dsh-home",
+                str(dsh_home),
+                "--dsh-cordis",
+                str(cordis),
+                "--dsh-model",
+                "mock-model",
+            ]
+        )
+    argv.extend(
+        [
+            "--validation-command-json",
+            json.dumps(_validator_command()),
+            "--validation-failure-kind",
+            "repair_required",
+            "--scan-root",
+            str(registry.parent.parent),
+            "--no-global-sync",
+            "--timeout-seconds",
+            str(timeout_seconds),
+        ]
+    )
+    return argv
 
 
 def _quota_spend_count(runtime: Path) -> int:
@@ -241,6 +259,12 @@ def _quota_spend_count(runtime: Path) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
+    parser.add_argument(
+        "--host",
+        choices=["generic-cli", "dsh"],
+        default="generic-cli",
+        help="Exercise the subprocess adapter or the built-in in-process host.",
+    )
     args = parser.parse_args()
 
     try:
@@ -290,28 +314,35 @@ def main() -> int:
     base_url = f"http://127.0.0.1:{server.server_address[1]}"
     old_env = {
         key: os.environ.get(key)
-        for key in ("DEEPSEEK_BASE_URL", "DEEPSEEK_API_KEY", "DSH_CWD", "DSH_SESSION_ROOT")
+        for key in (
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+            "DSH_CWD",
+            "DSH_HOME",
+            "DSH_SESSION_ROOT",
+        )
     }
     try:
         os.environ["DEEPSEEK_BASE_URL"] = base_url
         os.environ["DEEPSEEK_API_KEY"] = "dsh-real-e2e-mock-key"
-        os.environ["DSH_CWD"] = "."
+        for key in ("DSH_CWD", "DSH_HOME", "DSH_SESSION_ROOT"):
+            os.environ.pop(key, None)
         with tempfile.TemporaryDirectory(prefix="loopx-turn-dsh-real-e2e-") as directory:
             root = Path(directory)
             project, runtime, workspace, registry = _write_fixture(root)
             session_root = root / "sessions"
             session_root.mkdir(parents=True)
+            dsh_home = root / "dsh-home"
             cordis = _write_minimal_cordis(session_root)
             marker_path = workspace / MARKER_NAME
-            os.environ["DSH_SESSION_ROOT"] = str(session_root)
 
             base = _base_argv(
                 registry=registry,
                 runtime=runtime,
                 workspace=workspace,
-                session_root=session_root,
+                dsh_home=dsh_home,
                 cordis=cordis,
-                base_url=base_url,
+                host=args.host,
                 timeout_seconds=args.timeout_seconds,
             )
             exit_code, payload = _run_cli([*base, "--execute"])
@@ -334,6 +365,9 @@ def main() -> int:
             summary = {
                 "schema_version": "loopx_turn_dsh_real_e2e_v1",
                 "real_dsh_invoked": True,
+                "host": args.host,
+                "ambient_dsh_home_cleared": True,
+                "configured_dsh_home_created": dsh_home.is_dir(),
                 "mock_llm_base_url": base_url,
                 "exit_code": exit_code,
                 "status": payload.get("status"),
@@ -375,6 +409,7 @@ def main() -> int:
     ok = (
         exit_code == 0
         and summary["status"] == "committed"
+        and summary["configured_dsh_home_created"] is True
         and summary["result_kind"] == "validated_progress"
         and (summary["validation"] or {}).get("status") == "passed"
         and effects == expected_effects

--- a/examples/project/host-mode-plan-cli-smoke.py
+++ b/examples/project/host-mode-plan-cli-smoke.py
@@ -232,6 +232,24 @@ def test_cli_fails_closed_on_bad_intent() -> None:
     assert payload["suggestions"], payload
 
 
+def test_cli_rejects_dsh_as_a_visible_host_identity() -> None:
+    proc = run_cli(
+        "--format",
+        "json",
+        "host-mode-plan",
+        "--goal-id",
+        "host-mode-plan-cli-fixture",
+        "--intent",
+        "watch_each_turn",
+        "--host-capability",
+        "visible_session",
+        "--host-identity",
+        "dsh",
+    )
+    assert proc.returncode == 2, (proc.stdout, proc.stderr)
+    assert "invalid choice" in proc.stderr, proc.stderr
+
+
 def test_cli_reports_missing_capabilities_and_stop_steps() -> None:
     proc = run_cli(
         "--format",
@@ -273,6 +291,7 @@ def main() -> int:
     test_cli_visible_mode_maps_opencode_to_goal_loop_connector()
     test_cli_shell_service_fails_closed_without_adapter_and_validator()
     test_cli_fails_closed_on_bad_intent()
+    test_cli_rejects_dsh_as_a_visible_host_identity()
     test_cli_reports_missing_capabilities_and_stop_steps()
     test_command_is_discoverable()
     print("host-mode-plan-cli-smoke ok")

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -259,7 +259,9 @@ def handle_turn_command(
                     )
             else:
                 if args.host_command_json:
-                    raise ValueError("codex-cli does not accept --host-command-json")
+                    raise ValueError(
+                        f"{args.host} does not accept --host-command-json"
+                    )
                 raw_argv = None
             if args.validation_command_json:
                 raw_validation_argv = json.loads(args.validation_command_json)
@@ -924,6 +926,42 @@ def handle_turn_command(
                     return codex_cli_session_binding(runtime_root, turn_envelope)
 
                 session_binding_resolver = resolve_built_in_session_binding
+            elif args.host == "dsh":
+                from ..dsh_goal_mode.turn_host_adapter import (
+                    DshHostConfig,
+                    run_dsh_host,
+                )
+
+                dsh_config = DshHostConfig(
+                    workspace=project,
+                    **{
+                        key: value
+                        for key, value in {
+                            "provider": args.dsh_provider,
+                            "model": args.dsh_model,
+                            "max_tokens": args.dsh_max_tokens,
+                            "dsh_home": (
+                                Path(args.dsh_home) if args.dsh_home else None
+                            ),
+                            "cordis": Path(args.dsh_cordis) if args.dsh_cordis else None,
+                            "runtime_bin": args.dsh_runtime_bin,
+                            "request_timeout_seconds": max(
+                                1.0, args.timeout_seconds - 5.0
+                            ),
+                            "dsh_runner": (
+                                Path(args.dsh_runner) if args.dsh_runner else None
+                            ),
+                        }.items()
+                        if value is not None
+                    },
+                )
+
+                def run_dsh_built_in_host(
+                    request: Mapping[str, Any],
+                ) -> dict[str, Any]:
+                    return run_dsh_host(request, config=dsh_config)
+
+                host_runner = run_dsh_built_in_host
 
             payload = run_loopx_turn_once(
                 payload,

--- a/loopx/cli_commands/turn_registration.py
+++ b/loopx/cli_commands/turn_registration.py
@@ -85,7 +85,7 @@ def register_turn_commands(
     _add_turn_decision_arguments(
         run_once,
         default_host="generic-cli",
-        host_choices=["codex-cli", "generic-cli"],
+        host_choices=["codex-cli", "dsh", "generic-cli"],
         execution_mode_choices=["isolated-headless"],
         default_execution_mode="isolated-headless",
     )
@@ -130,6 +130,35 @@ def register_turn_commands(
         choices=["read-only", "workspace-write"],
         default="read-only",
         help="Sandbox for a new Codex CLI session; resume preserves its original session policy.",
+    )
+    run_once.add_argument(
+        "--dsh-provider",
+        help="Provider for the built-in dsh host; defaults to DSH_PROVIDER.",
+    )
+    run_once.add_argument(
+        "--dsh-model",
+        help="Model for the built-in dsh host; defaults to DSH_MODEL.",
+    )
+    run_once.add_argument("--dsh-max-tokens", type=int)
+    run_once.add_argument(
+        "--dsh-home",
+        help=(
+            "Explicit DeepSeek Harness home; defaults to DSH_HOME or "
+            "<project>/.local/.dsh-sessions."
+        ),
+    )
+    run_once.add_argument(
+        "--dsh-cordis",
+        help="cordis.yml used by the built-in dsh host runtime.",
+    )
+    run_once.add_argument("--dsh-runtime-bin")
+    run_once.add_argument(
+        "--dsh-runner",
+        help=(
+            "Explicit runner hook intended for hermetic tests; this is not a "
+            "permission boundary. Path to a Python module exposing "
+            "run_dsh_turn(...) used instead of the DeepSeek Harness SDK."
+        ),
     )
     run_once.add_argument("--timeout-seconds", type=float, default=120.0)
     run_once.add_argument(

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -415,6 +415,9 @@ def scheduler_execution_context_for_turn(
         "generic-cli": HostSurface.GENERIC_CLI.value,
         "claude-code": HostSurface.CLAUDE_CODE.value,
         "pi": HostSurface.GENERIC_CLI.value,
+        # The built-in dsh host runs one bounded in-process attempt under the
+        # generic-cli scheduling surface, same as the pi visible alias.
+        "dsh": HostSurface.GENERIC_CLI.value,
     }.get(host, host)
     normalized_mode = {
         "interactive-visible": ExecutionMode.INTERACTIVE.value,

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -17,7 +17,7 @@ LOOPX_TURN_PLAN_SCHEMA_VERSION = "loopx_turn_plan_v0"
 LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION = "loopx_turn_session_binding_v0"
 LOOPX_CHILD_HOST_OPERATION_SCHEMA_VERSION = "loopx_child_host_operation_v0"
 TURN_ENVELOPE_SCHEMA_VERSION = "loopx_turn_envelope_v0"
-SUPPORTED_HOSTS = {"codex-cli", "claude-code", "generic-cli"}
+SUPPORTED_HOSTS = {"codex-cli", "claude-code", "dsh", "generic-cli"}
 SUPPORTED_EXECUTION_MODES = {"interactive-visible", "isolated-headless"}
 HOST_CHILD_CONTEXT_OPERATIONS = {
     "codex-cli": {

--- a/loopx/dsh_goal_mode/README.md
+++ b/loopx/dsh_goal_mode/README.md
@@ -39,27 +39,78 @@ python3 scripts/dsh_turn_host_adapter.py --cordis /path/to/cordis.yml
 ```
 
 Flags: `--provider`, `--model`, `--max-tokens`, `--workspace`,
-`--session-root`, `--cordis`, `--runtime-bin`,
-`--request-timeout-seconds`, and `--dsh-runner` (hermetic tests only: path to
-a Python module exposing `run_dsh_turn(...)`).
+`--dsh-home` (`--session-root` remains a compatibility alias), `--cordis`,
+`--runtime-bin`, `--request-timeout-seconds`, and `--dsh-runner`. The runner
+option is an explicit test hook; LoopX does not machine-enforce where it may be
+used, and the caller already owns local host-execution authority.
+
+## In-process host (`--host dsh`)
+
+`loopx turn run-once --host dsh` runs the same adapter inside the CLI process
+instead of a generic subprocess. Provider failures then reach the Turn
+journal as typed `loopx_turn_host_failure_v0` kinds instead of collapsing to
+`unknown` through a bare nonzero exit, so bounded same-Turn retry stays
+available. Both failure shapes are covered: a raised transport exception and
+the SDK's normal terminal report (`RunResult.finish_reason == "error"` with a
+structured `turn/end` reason and no Python exception at all).
+
+Classification follows the `loopx-turn-v0` precedence: a known provider
+`error.code` wins over HTTP status and prose, an unknown non-empty code fails
+closed to `unknown` and blocks every lower tier, HTTP status decides only
+when no more specific code exists, and bounded message matching applies only
+when no structured signal exists. Signals that disagree within one tier fold
+to `unknown`. The SDK's stable `SERVER` code covers HTTP 5xx responses and maps
+to the retryable `provider_overloaded` bucket even when an intermediate
+serializer omits the duplicate HTTP status. Its hard-quota `QUOTA` code remains
+non-retryable, while its explicitly retryable `EMPTY_RESPONSE` code maps to the
+closest LoopX transient bucket, `transport_lost`.
+
+CLI flags: `--dsh-provider`, `--dsh-model`, `--dsh-max-tokens`,
+`--dsh-home`, `--dsh-cordis`, `--dsh-runtime-bin`, and `--dsh-runner`.
+Against the current SDK config surface the home maps to `dsh_home`, the runtime
+binary maps to `dsh_bin`, and a cordis file rides as one `patches` entry.
+Home precedence is explicit CLI value, then `DSH_HOME`, then
+`<workspace>/.local/.dsh-sessions`; LoopX creates the selected local directory
+before SDK launch. Session persistence still belongs to the selected dsh
+composition, so this mode does not promise cross-turn dsh session continuity.
+The generic-cli subprocess preserves its legacy contract: an exception-free
+terminal SDK error produces a typed `wait` result, while the in-process host
+turns the same outcome into a retry-aware host failure. Hermetic verification:
+`python3 examples/loopx-turn-dsh-builtin-host-e2e-smoke.py`.
+
+The SDK derives `finish_reason` from the last `turn/end.reason.kind`; the
+adapter rejects contradictory or malformed runner outcomes as
+`contract_rejected`. Result parsing and shaping failures use the same typed
+contract failure instead of collapsing into `unknown`.
 
 ## Requirements
 
-- Optional dependency group `loopx[deepseek-harness]`
-  (the `deepseek-harness-sdk` import) or a compatible runner via
+- Optional dependency group `loopx[deepseek-harness]`, currently pinned to the
+  validated `deepseek-harness-sdk==0.1.2a3` API, or a compatible runner via
   `--dsh-runner`.
 - A dsh `cordis.yml` plus any `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL`
   settings for the real runtime.
-- Defaults come from `DSH_MODEL` / `DSH_PROVIDER` when set.
+- Defaults come from `DSH_MODEL` / `DSH_PROVIDER` when set. `DSH_HOME` may
+  override the workspace-local home when no CLI home is supplied.
 
 ## Boundary
 
-Opaque dsh session roots (default `<workspace>/.local/.dsh-sessions`) stay
-local and never enter public LoopX evidence. The adapter never reads
-goal/todo state, builds prompts from todo ids, writes LoopX state, spends
-quota, or validates its own work. A missing or malformed typed result fails
-closed as a `wait` result with no quota spend.
+The explicit dsh runtime home (default `<workspace>/.local/.dsh-sessions`)
+stays local and never enters public LoopX evidence. The composition, not this
+path name, owns session persistence. The adapter never reads goal/todo state,
+builds prompts from todo ids, writes LoopX state, spends quota, or validates
+its own work. A valid final response with no typed JSON candidate becomes a
+conservative `wait`; an invalid runner/result shape is a typed
+`contract_rejected` host failure. Neither path may spend quota.
+
+The adapter derives a stable owner-local session id, but LoopX does not yet
+project or validate a DSH Host Session Binding. The built-in surface therefore
+does not claim managed supervisor recovery, outer wake/timer ownership, or a
+cross-process resume guarantee.
 
 See `docs/integrations/deepseek-harness-connector.md` for the full connector
 walkthrough and `examples/dsh-turn-host-adapter-smoke.py` plus
-`examples/loopx-turn-dsh-e2e-smoke.py` for hermetic smokes.
+`examples/loopx-turn-dsh-e2e-smoke.py` for hermetic smokes. With the optional
+SDK installed, run `examples/loopx-turn-dsh-real-e2e-smoke.py` once with
+`--host generic-cli` and once with `--host dsh`; both paths clear ambient DSH
+home variables and prove the explicit SDK-home wiring.

--- a/loopx/dsh_goal_mode/host_failure_map.py
+++ b/loopx/dsh_goal_mode/host_failure_map.py
@@ -1,0 +1,281 @@
+"""Map DeepSeek Harness execution failures to typed LoopX host failure kinds.
+
+Classification follows the merged ``loopx-turn-v0`` precedence: a known
+provider ``error.code`` wins over HTTP status and prose; an unknown non-empty
+code becomes ``unknown`` and blocks every lower tier; HTTP status decides only
+when no more-specific code exists; exception class names and bounded message
+matching apply only when no structured signal exists at all. Within one tier,
+signals that disagree fold to ``unknown`` regardless of their order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+_MAX_CAUSE_DEPTH = 4
+_MAX_REASON_DEPTH = 3
+
+# Tier 1: structured provider codes. The dsh provider-neutral taxonomy comes
+# first; common provider strings keep working. Stable codes decide without
+# requiring a duplicated HTTP status on every serialization boundary.
+_CODE_KINDS: dict[str, str] = {
+    "aborted": "unknown",
+    "auth": "auth_failed",
+    "authentication_error": "auth_failed",
+    "at_capacity": "provider_capacity",
+    "context_window_exceeded": "contract_rejected",
+    "empty_response": "transport_lost",
+    "insufficient_balance": "quota_exhausted",
+    "insufficient_capacity": "provider_capacity",
+    "insufficient_quota": "quota_exhausted",
+    "invalid_api_key": "auth_failed",
+    "invalid_credential": "auth_failed",
+    "invalid_request": "contract_rejected",
+    "llm_stream_idle_timeout": "executor_timeout",
+    "malformed_response": "contract_rejected",
+    "missing_credential": "auth_failed",
+    "model_at_capacity": "provider_capacity",
+    "overloaded": "provider_overloaded",
+    "overloaded_error": "provider_overloaded",
+    "permission_denied": "auth_failed",
+    "quota": "quota_exhausted",
+    "quota_exceeded": "quota_exhausted",
+    "rate_limit": "rate_limited",
+    "rate_limit_exceeded": "rate_limited",
+    "rate_limited": "rate_limited",
+    "request_timeout": "executor_timeout",
+    "request_extension": "contract_rejected",
+    "server": "provider_overloaded",
+    "server_overloaded": "provider_overloaded",
+    "stream_closed": "contract_rejected",
+    "timeout": "executor_timeout",
+    "transport": "transport_lost",
+    "unsupported_content": "contract_rejected",
+    "unsupported_reasoning_effort": "contract_rejected",
+}
+
+# Tier 2: HTTP status, consulted only when no code decided the failure.
+_STATUS_KINDS = {
+    401: "auth_failed",
+    402: "quota_exhausted",
+    403: "auth_failed",
+    408: "executor_timeout",
+    429: "rate_limited",
+    503: "provider_overloaded",
+}
+
+# Tier 3: exception class names; more specific patterns first.
+_TYPE_NAME_KINDS = (
+    ("sdkprotocol", "contract_rejected"),
+    ("transportclosed", "transport_lost"),
+    ("timeout", "executor_timeout"),
+    ("connection", "transport_lost"),
+    ("brokenpipe", "transport_lost"),
+    ("protocolerror", "transport_lost"),
+)
+
+# Tier 4: bounded prose fallback, reachable only without structured signals.
+_MESSAGE_KINDS = (
+    ("insufficient balance", "quota_exhausted"),
+    ("at capacity", "provider_capacity"),
+    ("insufficient capacity", "provider_capacity"),
+    ("no capacity", "provider_capacity"),
+    ("rate limit", "rate_limited"),
+    ("too many requests", "rate_limited"),
+    ("overloaded", "provider_overloaded"),
+    ("timed out", "executor_timeout"),
+    ("timeout", "executor_timeout"),
+    ("connection reset", "transport_lost"),
+    ("connection refused", "transport_lost"),
+    ("connection aborted", "transport_lost"),
+    ("connection error", "transport_lost"),
+    ("unauthorized", "auth_failed"),
+    ("invalid api key", "auth_failed"),
+    ("authentication failed", "auth_failed"),
+)
+
+_STATUS_FIELDS = ("status_code", "status", "http_status", "http_status_code")
+_CODE_FIELDS = ("code", "error_code", "errorCode")
+
+
+def _exception_chain(exc: BaseException) -> list[BaseException]:
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while (
+        current is not None
+        and id(current) not in seen
+        and len(chain) < _MAX_CAUSE_DEPTH
+    ):
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def _signal_containers(err: BaseException) -> list[object]:
+    containers: list[object] = [err]
+    for attribute in ("response", "body", "error"):
+        value = getattr(err, attribute, None)
+        if value is not None and not isinstance(value, BaseException):
+            containers.append(value)
+    return containers
+
+
+def _field_value(container: object, field: str) -> object:
+    if isinstance(container, Mapping):
+        return container.get(field)
+    return getattr(container, field, None)
+
+
+def _meaningful(value: object) -> bool:
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return isinstance(value, (int, float))
+
+
+def _status_kind(value: object) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return "unknown"
+    try:
+        status = int(value)
+    except (TypeError, ValueError):
+        return "unknown"
+    return _STATUS_KINDS.get(status, "unknown")
+
+
+def _normalized_code(value: object) -> str:
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _reduce(kinds: list[str]) -> str | None:
+    if not kinds:
+        return None
+    distinct = set(kinds)
+    if len(distinct) == 1:
+        return next(iter(distinct))
+    return "unknown"
+
+
+def _classify_signals(
+    *,
+    codes: list[object],
+    statuses: list[object],
+    type_names: list[str],
+    messages: list[str],
+) -> str:
+    # Tier 1: a known code decides; an unknown non-empty code fails the whole
+    # classification closed. Codes never defer to exception names or prose.
+    code_kinds: list[str] = []
+    for value in codes:
+        mapped = _CODE_KINDS.get(_normalized_code(value), "unknown")
+        code_kinds.append(mapped)
+    reduced = _reduce(code_kinds)
+    if reduced is not None:
+        return reduced
+
+    # Tier 2: HTTP status decides only when no code did.
+    reduced = _reduce([_status_kind(value) for value in statuses])
+    if reduced is not None:
+        return reduced
+
+    # Any remaining structured status signal must not become a different
+    # category through provider-controlled prose or a coincidental Python
+    # exception name.
+    if codes or statuses:
+        return "unknown"
+
+    # Tier 3: exception class names.
+    type_kinds: list[str] = []
+    for name in type_names:
+        lowered = name.lower()
+        for pattern, kind in _TYPE_NAME_KINDS:
+            if pattern in lowered:
+                type_kinds.append(kind)
+                break
+    reduced = _reduce(type_kinds)
+    if reduced is not None:
+        return reduced
+
+    # Tier 4: bounded prose fallback.
+    message_kinds: list[str] = []
+    for message in messages:
+        lowered = message.lower()
+        for pattern, kind in _MESSAGE_KINDS:
+            if pattern in lowered:
+                message_kinds.append(kind)
+    return _reduce(message_kinds) or "unknown"
+
+
+def classify_dsh_failure(exc: BaseException) -> str:
+    """Classify one adapter execution exception into a host failure kind."""
+
+    chain = _exception_chain(exc)
+    codes: list[object] = []
+    statuses: list[object] = []
+    for err in chain:
+        for container in _signal_containers(err):
+            for field in _CODE_FIELDS:
+                value = _field_value(container, field)
+                if _meaningful(value):
+                    codes.append(value)
+            for field in _STATUS_FIELDS:
+                value = _field_value(container, field)
+                if _meaningful(value):
+                    statuses.append(value)
+    return _classify_signals(
+        codes=codes,
+        statuses=statuses,
+        type_names=[type(err).__name__ for err in chain],
+        messages=[str(err) for err in chain],
+    )
+
+
+def _reason_containers(reason: Mapping[str, object]) -> list[Mapping[str, object]]:
+    containers: list[Mapping[str, object]] = [reason]
+    frontier: list[Mapping[str, object]] = [reason]
+    for _ in range(_MAX_REASON_DEPTH):
+        next_frontier: list[Mapping[str, object]] = []
+        for container in frontier:
+            for value in container.values():
+                if isinstance(value, Mapping):
+                    next_frontier.append(value)
+                    containers.append(value)
+        frontier = next_frontier
+        if not frontier:
+            break
+    return containers
+
+
+def classify_dsh_terminal_reason(reason: Mapping[str, object]) -> str:
+    """Classify one structured ``turn/end`` failure reason.
+
+    The DeepSeek Harness SDK reports provider failures as a terminal
+    ``RunResult`` (``finish_reason == "error"`` with a structured reason on
+    the last ``turn/end`` event) rather than a Python exception, so this
+    entry point classifies the reason mapping directly.
+    """
+
+    codes: list[object] = []
+    statuses: list[object] = []
+    messages: list[str] = []
+    for container in _reason_containers(reason):
+        for field in _CODE_FIELDS:
+            value = container.get(field)
+            if _meaningful(value):
+                codes.append(value)
+        for field in _STATUS_FIELDS:
+            value = container.get(field)
+            if _meaningful(value):
+                statuses.append(value)
+        message = container.get("message")
+        if isinstance(message, str) and message.strip():
+            messages.append(message)
+    return _classify_signals(
+        codes=codes,
+        statuses=statuses,
+        type_names=[],
+        messages=messages,
+    )

--- a/loopx/dsh_goal_mode/turn_host_adapter.py
+++ b/loopx/dsh_goal_mode/turn_host_adapter.py
@@ -26,13 +26,17 @@ import importlib.util
 import json
 import os
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ..control_plane.quota.turn_envelope import (
     turn_envelope_action_signature_document,
 )
+from ..control_plane.turn_driver.host_failure import BuiltInHostError
+
+from .host_failure_map import classify_dsh_failure, classify_dsh_terminal_reason
 
 LOOPX_TURN_HOST_REQUEST_SCHEMA = "loopx_turn_host_request_v0"
 LOOPX_TURN_RESULT_SCHEMA = "loopx_turn_result_v0"
@@ -290,6 +294,118 @@ def build_result(
     return result
 
 
+def build_sdk_config(
+    *,
+    provider: str,
+    model: str,
+    workspace: Path,
+    dsh_home: Path,
+    max_tokens: int | None,
+    cordis: Path | None,
+    runtime_bin: str | None,
+    request_timeout_seconds: float | None,
+) -> dict[str, Any]:
+    """Build kwargs for the current ``DeepSeekHarnessConfig`` surface.
+
+    The current SDK config calls its explicit local runtime root ``dsh_home``;
+    the adapter's legacy ``session_root`` spelling maps to that field. The
+    runtime binary maps to ``dsh_bin`` and a cordis file rides as one
+    ``patches`` entry.
+    """
+
+    config: dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "cwd": str(workspace),
+        "dsh_home": str(dsh_home),
+    }
+    if max_tokens is not None:
+        config["max_tokens"] = max_tokens
+    if cordis is not None:
+        config["patches"] = (str(cordis.expanduser().resolve()),)
+    if runtime_bin is not None:
+        config["dsh_bin"] = runtime_bin
+    if request_timeout_seconds is not None:
+        config["request_timeout_seconds"] = request_timeout_seconds
+    return config
+
+
+class DshHostResultError(ValueError):
+    """The SDK or an explicit runner returned an invalid result shape."""
+
+
+def _result_field(result: object, name: str) -> object:
+    if isinstance(result, Mapping):
+        return result.get(name)
+    return getattr(result, name, None)
+
+
+def _last_turn_end_reason(events: object) -> dict[str, Any] | None:
+    if events is None:
+        return None
+    if not isinstance(events, Sequence) or isinstance(events, (str, bytes)):
+        raise DshHostResultError("dsh runner events must be a sequence or null")
+    if not all(isinstance(event, Mapping) for event in events):
+        raise DshHostResultError("dsh runner events must contain only objects")
+    for event in reversed(events):
+        if event.get("type") != "turn/end":
+            continue
+        data = event.get("data")
+        if not isinstance(data, Mapping):
+            raise DshHostResultError("dsh turn/end event requires object data")
+        reason = data.get("reason")
+        if not isinstance(reason, Mapping) or not isinstance(reason.get("kind"), str):
+            raise DshHostResultError(
+                "dsh turn/end event requires object reason with string kind"
+            )
+        return dict(reason)
+    return None
+
+
+def normalize_runner_outcome(value: object) -> dict[str, Any]:
+    """Normalize and validate one SDK or explicit-runner result.
+
+    The real SDK derives ``finish_reason`` from the last ``turn/end`` reason.
+    Enforcing that invariant prevents a contradictory result from selecting a
+    success path while carrying a terminal provider failure, or vice versa.
+    Legacy runners may still return a bare final-response string.
+    """
+
+    if isinstance(value, str):
+        return {"final_response": value, "finish_reason": None, "events": []}
+
+    final_response = _result_field(value, "final_response")
+    if not isinstance(final_response, str):
+        raise DshHostResultError("dsh runner result requires string final_response")
+
+    finish_reason = _result_field(value, "finish_reason")
+    if finish_reason is not None and not isinstance(finish_reason, str):
+        raise DshHostResultError("dsh runner finish_reason must be a string or null")
+
+    raw_events = _result_field(value, "events")
+    terminal_reason = _last_turn_end_reason(raw_events)
+    terminal_kind = str(terminal_reason["kind"]) if terminal_reason is not None else None
+    if finish_reason is None:
+        finish_reason = terminal_kind
+    elif terminal_kind is not None and terminal_kind != finish_reason:
+        raise DshHostResultError(
+            "dsh runner finish_reason does not match the last turn/end reason"
+        )
+
+    events = (
+        []
+        if raw_events is None
+        else list(raw_events)
+        if isinstance(raw_events, Sequence) and not isinstance(raw_events, (str, bytes))
+        else []  # Unreachable: _last_turn_end_reason validates the value.
+    )
+    return {
+        "final_response": final_response,
+        "finish_reason": finish_reason,
+        "events": events,
+    }
+
+
 def run_dsh_turn(
     *,
     prompt: str,
@@ -302,8 +418,14 @@ def run_dsh_turn(
     cordis: Path | None,
     runtime_bin: str | None,
     request_timeout_seconds: float | None,
-) -> str:
-    """Run one bounded DeepSeek Harness session through the Python SDK."""
+) -> dict[str, Any]:
+    """Run one bounded DeepSeek Harness session through the Python SDK.
+
+    Returns the terminal outcome (final response, finish reason, events)
+    instead of only the final response: the SDK reports provider failures
+    through ``RunResult.finish_reason`` and the last ``turn/end`` event
+    rather than raising a Python exception.
+    """
 
     try:
         from deepseek_harness import DeepSeekHarness, DeepSeekHarnessConfig
@@ -313,31 +435,55 @@ def run_dsh_turn(
             "`python -m pip install 'loopx[deepseek-harness]'`"
         ) from exc
 
-    config: dict[str, Any] = {
-        "provider": provider,
-        "model": model,
-        "cwd": str(workspace),
-        "session_root": str(session_root),
-    }
-    if max_tokens is not None:
-        config["max_tokens"] = max_tokens
-    if cordis is not None:
-        config["cordis"] = str(cordis)
-    if runtime_bin is not None:
-        config["runtime_bin"] = runtime_bin
-    if request_timeout_seconds is not None:
-        config["request_timeout_seconds"] = request_timeout_seconds
-
+    config = build_sdk_config(
+        provider=provider,
+        model=model,
+        workspace=workspace,
+        dsh_home=session_root,
+        max_tokens=max_tokens,
+        cordis=cordis,
+        runtime_bin=runtime_bin,
+        request_timeout_seconds=request_timeout_seconds,
+    )
     with DeepSeekHarness(DeepSeekHarnessConfig(**config)) as harness:
-        return harness.run(prompt, session_id=session_id).final_response
+        result = harness.run(prompt, session_id=session_id)
+    return normalize_runner_outcome(result)
 
 
-def load_dsh_runner(path: Path):
-    """Load a test/production runner module exposing ``run_dsh_turn``.
+def terminal_error_reason(outcome: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Extract the structured failure reason from a terminal outcome.
 
-    The runner module must expose the same keyword signature as
-    :func:`run_dsh_turn`. This is primarily used by hermetic smokes so the
-    repository does not need a real DeepSeek Harness SDK/runtime installed.
+    Returns the last ``turn/end`` reason when the run ended in error, or a
+    minimal reason when ``finish_reason == "error"`` arrives without one.
+    """
+
+    reason: dict[str, Any] | None = None
+    for event in reversed(list(outcome.get("events") or [])):
+        if not isinstance(event, Mapping) or event.get("type") != "turn/end":
+            continue
+        data = _mapping(event.get("data"))
+        candidate = _mapping(data.get("reason"))
+        if candidate:
+            reason = candidate
+        break
+    if reason is not None and reason.get("kind") == "error":
+        return reason
+    if outcome.get("finish_reason") == "error":
+        # A contradictory non-error turn/end reason must not leak its fields
+        # into failure classification.
+        return {"kind": "error"}
+    return None
+
+
+def load_dsh_runner(path: Path) -> Callable[..., object]:
+    """Load an explicit runner hook exposing ``run_dsh_turn``.
+
+    The runner module must expose the same legacy keyword signature as
+    :func:`run_dsh_turn`, including ``session_root``. It may return either
+    the legacy bare final-response string or an outcome mapping carrying
+    ``final_response``/``finish_reason``/``events``. This seam is primarily
+    used by hermetic smokes so the repository does not need a real DeepSeek
+    Harness SDK/runtime installed.
     """
 
     spec = importlib.util.spec_from_file_location("dsh_turn_runner", path)
@@ -347,13 +493,163 @@ def load_dsh_runner(path: Path):
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     runner = getattr(module, "run_dsh_turn", None)
-    if runner is None:
-        raise AttributeError(f"{path} must define run_dsh_turn(...)")
-    return runner
+    if not callable(runner):
+        raise DshHostResultError(f"{path} must define callable run_dsh_turn(...)")
+    return cast(Callable[..., object], runner)
 
 
 def _default_session_root(workspace: Path) -> Path:
     return workspace / ".local" / DEFAULT_SESSION_ROOT_NAME
+
+
+def _resolve_dsh_home(workspace: Path, configured: Path | None) -> Path:
+    """Resolve the explicit SDK home without falling back to a user-global path."""
+
+    if configured is not None:
+        return configured.expanduser().resolve()
+    environment = os.environ.get("DSH_HOME", "").strip()
+    if environment:
+        return Path(environment).expanduser().resolve()
+    return _default_session_root(workspace).expanduser().resolve()
+
+
+@dataclass(frozen=True)
+class DshHostConfig:
+    """Owner-local runtime configuration for one bounded dsh host attempt."""
+
+    workspace: Path
+    provider: str = DEFAULT_PROVIDER
+    model: str = DEFAULT_MODEL
+    max_tokens: int | None = None
+    dsh_home: Path | None = None
+    cordis: Path | None = None
+    runtime_bin: str | None = None
+    request_timeout_seconds: float | None = None
+    dsh_runner: Path | None = None
+
+
+def _derive_session_id(request: Mapping[str, Any], turn_key: str) -> str:
+    # Keep the opaque dsh session keyed by the same (goal, agent, todo) lineage
+    # LoopX already uses for the Turn transaction. The exact value is a local
+    # adapter concern and must not enter public LoopX state.
+    envelope = _mapping(request.get("turn_envelope"))
+    action = _mapping(envelope.get("action"))
+    selected_todo = _mapping(action.get("selected_todo"))
+    return "-".join(
+        str(value)
+        for value in (
+            envelope.get("goal_id"),
+            envelope.get("agent_id"),
+            selected_todo.get("todo_id"),
+        )
+        if value
+    ) or f"dsh-{turn_key.removeprefix('sha256:')[:24]}"
+
+
+def _execute_turn_host_request(
+    request: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    *,
+    config: DshHostConfig,
+    terminal_errors_as_host_failure: bool,
+    warn: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    workspace = config.workspace.expanduser().resolve()
+    dsh_home = _resolve_dsh_home(workspace, config.dsh_home)
+    dsh_home.mkdir(parents=True, exist_ok=True)
+    session_id = _derive_session_id(request, str(request.get("turn_key") or ""))
+
+    try:
+        prompt = render_prompt(authority)
+        runner = (
+            load_dsh_runner(config.dsh_runner.expanduser().resolve())
+            if config.dsh_runner is not None
+            else run_dsh_turn
+        )
+        outcome = normalize_runner_outcome(
+            runner(
+                prompt=prompt,
+                session_id=session_id,
+                workspace=workspace,
+                # Preserve the established runner keyword while mapping the
+                # path to the current SDK's explicit dsh_home field.
+                session_root=dsh_home,
+                provider=config.provider,
+                model=config.model,
+                max_tokens=config.max_tokens,
+                cordis=config.cordis,
+                runtime_bin=config.runtime_bin,
+                request_timeout_seconds=config.request_timeout_seconds,
+            )
+        )
+    except DshHostResultError as exc:
+        raise BuiltInHostError(
+            "dsh_host_result_rejected",
+            failure_kind="contract_rejected",
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 - adapter fails closed at boundary
+        raise BuiltInHostError(
+            "dsh_execution_failed",
+            failure_kind=classify_dsh_failure(exc),
+        ) from exc
+
+    failure_reason = terminal_error_reason(outcome)
+    if failure_reason is not None and terminal_errors_as_host_failure:
+        raise BuiltInHostError(
+            "dsh_execution_failed",
+            failure_kind=classify_dsh_terminal_reason(failure_reason),
+        )
+
+    try:
+        candidate = parse_model_json(outcome["final_response"])
+        if candidate is None and warn is not None:
+            warn("adapter: dsh final response did not contain a JSON result object")
+        return build_result(
+            request,
+            candidate,
+            fallback_reason=(
+                "dsh returned no typed JSON result; inspect the local dsh session"
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 - result contract fails closed
+        raise BuiltInHostError(
+            "dsh_host_result_rejected",
+            failure_kind="contract_rejected",
+        ) from exc
+
+
+def run_dsh_host(
+    request: Mapping[str, Any],
+    *,
+    config: DshHostConfig,
+) -> dict[str, Any]:
+    """Run one bounded dsh attempt as an in-process LoopX host runner.
+
+    Failures surface as :class:`BuiltInHostError` with a typed failure kind so
+    the Turn journal records retryability instead of a bare ``unknown``.
+    """
+
+    if (
+        not isinstance(request, Mapping)
+        or request.get("schema_version") != LOOPX_TURN_HOST_REQUEST_SCHEMA
+    ):
+        raise BuiltInHostError(
+            "dsh_request_schema_mismatch",
+            failure_kind="contract_rejected",
+        )
+    try:
+        authority = extract_turn_authority(request)
+    except ValueError as exc:
+        raise BuiltInHostError(
+            "dsh_turn_authority_rejected",
+            failure_kind="contract_rejected",
+        ) from exc
+    return _execute_turn_host_request(
+        request,
+        authority,
+        config=config,
+        terminal_errors_as_host_failure=True,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -362,14 +658,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--max-tokens", type=int, default=None)
     parser.add_argument("--workspace", default=os.getcwd())
-    parser.add_argument("--session-root", default=None)
+    parser.add_argument(
+        "--dsh-home",
+        "--session-root",
+        dest="dsh_home",
+        default=None,
+        help=(
+            "Explicit DeepSeek Harness home. --session-root remains a "
+            "compatibility alias; defaults to DSH_HOME or "
+            "<workspace>/.local/.dsh-sessions."
+        ),
+    )
     parser.add_argument("--cordis", default=None)
     parser.add_argument("--runtime-bin", default=None)
     parser.add_argument("--request-timeout-seconds", type=float, default=None)
     parser.add_argument(
         "--dsh-runner",
         default=None,
-        help="Path to a Python module exposing run_dsh_turn(...); used by tests.",
+        help=(
+            "Explicit runner hook intended for hermetic tests; this is not a "
+            "permission boundary."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -388,75 +697,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"adapter: invalid TurnEnvelope authority: {exc}", file=sys.stderr)
         return 2
 
-    workspace = Path(args.workspace).expanduser().resolve()
-    session_root = (
-        Path(args.session_root).expanduser().resolve()
-        if args.session_root
-        else _default_session_root(workspace)
+    config = DshHostConfig(
+        workspace=Path(args.workspace),
+        provider=args.provider,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        dsh_home=Path(args.dsh_home) if args.dsh_home else None,
+        cordis=Path(args.cordis).expanduser().resolve() if args.cordis else None,
+        runtime_bin=args.runtime_bin,
+        request_timeout_seconds=args.request_timeout_seconds,
+        dsh_runner=Path(args.dsh_runner) if args.dsh_runner else None,
     )
-    session_root.mkdir(parents=True, exist_ok=True)
-
-    turn_key = str(request.get("turn_key") or "")
-    # Keep the opaque dsh session keyed by the same (goal, agent, todo) lineage
-    # LoopX already uses for the Turn transaction. The exact value is a local
-    # adapter concern and must not enter public LoopX state.
-    envelope = _mapping(request.get("turn_envelope"))
-    action = _mapping(envelope.get("action"))
-    selected_todo = _mapping(action.get("selected_todo"))
-    session_id = "-".join(
-        str(value)
-        for value in (
-            envelope.get("goal_id"),
-            envelope.get("agent_id"),
-            selected_todo.get("todo_id"),
-        )
-        if value
-    ) or f"dsh-{turn_key.removeprefix('sha256:')[:24]}"
-
     try:
-        prompt = render_prompt(authority)
-        if args.dsh_runner:
-            runner = load_dsh_runner(Path(args.dsh_runner).expanduser().resolve())
-            final_response = runner(
-                prompt=prompt,
-                session_id=session_id,
-                workspace=workspace,
-                session_root=session_root,
-                provider=args.provider,
-                model=args.model,
-                max_tokens=args.max_tokens,
-                cordis=Path(args.cordis).expanduser().resolve() if args.cordis else None,
-                runtime_bin=args.runtime_bin,
-                request_timeout_seconds=args.request_timeout_seconds,
-            )
-        else:
-            final_response = run_dsh_turn(
-                prompt=prompt,
-                session_id=session_id,
-                workspace=workspace,
-                session_root=session_root,
-                provider=args.provider,
-                model=args.model,
-                max_tokens=args.max_tokens,
-                cordis=Path(args.cordis).expanduser().resolve() if args.cordis else None,
-                runtime_bin=args.runtime_bin,
-                request_timeout_seconds=args.request_timeout_seconds,
-            )
-    except Exception as exc:  # noqa: BLE001 - adapter fails closed at boundary
-        print(f"adapter: dsh execution failed: {type(exc).__name__}: {exc}", file=sys.stderr)
-        return 1
-
-    candidate = parse_model_json(final_response)
-    if candidate is None:
-        print(
-            "adapter: dsh final response did not contain a JSON result object",
-            file=sys.stderr,
+        result = _execute_turn_host_request(
+            request,
+            authority,
+            config=config,
+            terminal_errors_as_host_failure=False,
+            warn=lambda message: print(message, file=sys.stderr),
         )
-    result = build_result(
-        request,
-        candidate,
-        fallback_reason="dsh returned no typed JSON result; inspect the local dsh session",
-    )
+    except BuiltInHostError as exc:
+        cause = exc.__cause__
+        detail = (
+            f"{type(cause).__name__}: {cause}" if cause is not None else exc.reason
+        )
+        print(f"adapter: dsh execution failed: {detail}", file=sys.stderr)
+        return 1
     print(json.dumps(result, ensure_ascii=False, separators=(",", ":")), flush=True)
     return 0
 

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -1195,8 +1195,9 @@ def _deepseek_harness_activation(commands: dict[str, str]) -> dict[str, Any]:
     return {
         "host_surface": "deepseek_harness_automation_loop",
         "entry_command_hint": (
-            "loopx turn run-once with loopx.dsh_goal_mode "
-            "(python -m loopx.dsh_goal_mode; compat: scripts/dsh_turn_host_adapter.py)"
+            "loopx turn run-once --host dsh "
+            "(compat: --host generic-cli with python -m loopx.dsh_goal_mode or "
+            "scripts/dsh_turn_host_adapter.py)"
         ),
         "activation_method": "external_loop_driver",
         "activation_input_command": commands["heartbeat_prompt_json"],
@@ -1214,13 +1215,13 @@ def _deepseek_harness_activation(commands: dict[str, str]) -> dict[str, Any]:
             "Install the optional DeepSeek Harness SDK (`loopx[deepseek-harness]`).",
             "Prepare a dsh cordis.yml and any DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL settings.",
             "Run the heartbeat-prompt JSON command after project state and todos are written.",
-            "Wire `loopx turn run-once` with `--host generic-cli` and the "
-            "`loopx.dsh_goal_mode` host adapter (`python -m loopx.dsh_goal_mode`; "
-            "the legacy `scripts/dsh_turn_host_adapter.py` launcher still works).",
+            "Run `loopx turn run-once --host dsh`; use the generic-cli adapter "
+            "command only as a compatibility or rollback path.",
             "Start every automatic tick from quota should-run and stop when it says stop.",
         ],
         "success_criteria": [
             "The DeepSeek Harness adapter returns a typed loopx_turn_result_v0.",
+            "Structured dsh failures reach the Turn journal without provider prose.",
             "Independent validation passes before LoopX writes state or spends quota.",
             "Opaque dsh session roots stay outside public LoopX evidence.",
         ],

--- a/loopx/host_mode_planner.py
+++ b/loopx/host_mode_planner.py
@@ -120,11 +120,6 @@ SUPPORTED_HOST_CAPABILITIES = [
 ]
 _INTENT_PRIMARY_MODE = {meta["intent"]: mode for mode, meta in _MODE_METADATA.items()}
 
-# Host identities that map to a concrete visible Turn host. Visible TUI mapping
-# requires an explicit host identity so Codex CLI, Claude Code, and generic CLI
-# sessions keep their real host binding instead of a hard-coded Codex default.
-SUPPORTED_TURN_HOST_IDENTITIES = sorted(SUPPORTED_HOSTS)
-
 # Typed host identity -> runtime connector catalog id. Only identities with a
 # registered catalog connector may emit a host-specific visible mapping; any
 # other identity fails closed instead of fabricating a connector id.
@@ -135,6 +130,12 @@ VISIBLE_HOST_CONNECTOR_IDS: dict[str, str] = {
     # parity lives in the selector/catalog mapping, not a new Turn host kind.
     "generic-cli": "opencode_goal_loop",
 }
+
+# Host identities accepted by the public host-mode planner must own a concrete
+# visible connector. This is deliberately narrower than the Turn driver's
+# SUPPORTED_HOSTS: headless-only built-in hosts such as dsh do not become
+# visible identities merely by registering an execution backend.
+SUPPORTED_TURN_HOST_IDENTITIES = sorted(VISIBLE_HOST_CONNECTOR_IDS)
 
 # Host identities that are valid visible selections but map to the OpenCode
 # goal loop connector rather than their own Turn host kind.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Changelog = "https://github.com/huangruiteng/loopx/releases"
 
 [project.optional-dependencies]
 deepseek-harness = [
-  "deepseek-harness-sdk>=0.1.0rc5",
+  "deepseek-harness-sdk==0.1.2a3",
 ]
 test = [
   "jsonschema>=4.23,<5",

--- a/tests/dsh_goal_mode_capacity_runner.py
+++ b/tests/dsh_goal_mode_capacity_runner.py
@@ -1,0 +1,32 @@
+"""Hermetic failing dsh runner: returns a provider-capacity terminal outcome.
+
+Mirrors the SDK terminal envelope — provider errors arrive as a ``RunResult``
+with ``finish_reason == "error"`` and a structured reason on the last
+``turn/end`` event, not as a Python exception. ``MODEL_AT_CAPACITY`` is a
+provider-specific compatible code, not a DeepSeek-official adapter code. Not a
+pytest module (no ``test_`` prefix).
+"""
+
+from __future__ import annotations
+
+
+def run_dsh_turn(**_kwargs: object) -> dict[str, object]:
+    return {
+        "final_response": "",
+        "finish_reason": "error",
+        "events": [
+            {
+                "type": "turn/end",
+                "data": {
+                    "reason": {
+                        "kind": "error",
+                        "error": {
+                            "code": "MODEL_AT_CAPACITY",
+                            "status": 503,
+                            "message": "selected model is at capacity",
+                        },
+                    }
+                },
+            }
+        ],
+    }

--- a/tests/dsh_goal_mode_raising_runner.py
+++ b/tests/dsh_goal_mode_raising_runner.py
@@ -1,0 +1,11 @@
+"""Hermetic failing dsh runner: raises a bare transport-layer exception.
+
+Covers the exception classification path (no structured signal, prose
+fallback only). Not a pytest module (no ``test_`` prefix).
+"""
+
+from __future__ import annotations
+
+
+def run_dsh_turn(**_kwargs: object) -> str:
+    raise RuntimeError("selected model is at capacity")

--- a/tests/dsh_goal_mode_transport_runner.py
+++ b/tests/dsh_goal_mode_transport_runner.py
@@ -1,0 +1,24 @@
+"""Hermetic failing dsh runner using the official TRANSPORT terminal code."""
+
+from __future__ import annotations
+
+
+def run_dsh_turn(**_kwargs: object) -> dict[str, object]:
+    return {
+        "final_response": "",
+        "finish_reason": "error",
+        "events": [
+            {
+                "type": "turn/end",
+                "data": {
+                    "reason": {
+                        "kind": "error",
+                        "error": {
+                            "code": "TRANSPORT",
+                            "message": "provider-controlled detail",
+                        },
+                    }
+                },
+            }
+        ],
+    }

--- a/tests/test_dsh_goal_mode.py
+++ b/tests/test_dsh_goal_mode.py
@@ -6,12 +6,19 @@ import subprocess
 import sys
 from hashlib import sha256
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from loopx import dsh_goal_mode
 from loopx.control_plane.quota.turn_envelope import (
     turn_envelope_action_signature_document,
 )
-from loopx.dsh_goal_mode import turn_host_adapter
+from loopx.control_plane.turn_driver.host_failure import (
+    BuiltInHostError,
+    build_host_failure_record,
+)
+from loopx.dsh_goal_mode import host_failure_map, turn_host_adapter
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMPAT_LAUNCHER = REPO_ROOT / "scripts" / "dsh_turn_host_adapter.py"
@@ -218,6 +225,342 @@ def test_adapter_runs_hermetically_through_the_module_entry() -> None:
     assert result["classification"] == "fake dsh typed result"
 
 
+def test_classify_dsh_failure_maps_each_known_signal() -> None:
+    class _StatusError(Exception):
+        def __init__(self, status_code: int) -> None:
+            super().__init__("provider rejected the request")
+            self.status_code = status_code
+
+    cases = [
+        (_StatusError(429), "rate_limited"),
+        (_StatusError(402), "quota_exhausted"),
+        (_StatusError(401), "auth_failed"),
+        (_StatusError(503), "provider_overloaded"),
+        (RuntimeError("selected model is at capacity"), "provider_capacity"),
+        (TimeoutError("request stalled"), "executor_timeout"),
+        (ConnectionResetError("peer went away"), "transport_lost"),
+        (RuntimeError("something else entirely"), "unknown"),
+    ]
+    for exc, expected in cases:
+        assert host_failure_map.classify_dsh_failure(exc) == expected, expected
+
+
+def test_classify_known_code_wins_over_http_status() -> None:
+    # loopx-turn-v0: a known error.code wins over HTTP status, so a quota
+    # exhaustion stays non-retryable even when transported as HTTP 429.
+    class _StatusFirst(Exception):
+        status_code = 429
+        code = "insufficient_balance"
+
+    class _CodeFirst(Exception):
+        code = "QUOTA_EXCEEDED"
+        status_code = 429
+
+    assert (
+        host_failure_map.classify_dsh_failure(_StatusFirst("x")) == "quota_exhausted"
+    )
+    assert (
+        host_failure_map.classify_dsh_failure(_CodeFirst("x")) == "quota_exhausted"
+    )
+
+
+def test_classify_server_code_is_a_stable_provider_overload_signal() -> None:
+    class _ServerError(Exception):
+        code = "SERVER"
+
+    assert (
+        host_failure_map.classify_dsh_failure(_ServerError("x"))
+        == "provider_overloaded"
+    )
+
+
+def test_classify_conflicting_known_codes_fold_closed() -> None:
+    class _TwoCodes(Exception):
+        code = "QUOTA_EXCEEDED"
+        error_code = "RATE_LIMIT"
+
+    assert host_failure_map.classify_dsh_failure(_TwoCodes("x")) == "unknown"
+
+
+def test_classify_transport_closed_exception_type() -> None:
+    class TransportClosedError(Exception):
+        pass
+
+    assert (
+        host_failure_map.classify_dsh_failure(TransportClosedError("gone"))
+        == "transport_lost"
+    )
+
+
+def test_classify_terminal_reason_uses_structured_error() -> None:
+    reason = {
+        "kind": "error",
+        "error": {"code": "RATE_LIMIT", "status": 429, "message": "slow down"},
+    }
+    assert host_failure_map.classify_dsh_terminal_reason(reason) == "rate_limited"
+    assert host_failure_map.classify_dsh_terminal_reason({"kind": "error"}) == (
+        "unknown"
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("TRANSPORT", "transport_lost"),
+        ("MISSING_CREDENTIAL", "auth_failed"),
+        ("INVALID_CREDENTIAL", "auth_failed"),
+        ("QUOTA", "quota_exhausted"),
+        ("TIMEOUT", "executor_timeout"),
+        ("EMPTY_RESPONSE", "transport_lost"),
+        ("INVALID_REQUEST", "contract_rejected"),
+        ("CONTEXT_WINDOW_EXCEEDED", "contract_rejected"),
+        ("UNSUPPORTED_CONTENT", "contract_rejected"),
+        ("UNSUPPORTED_REASONING_EFFORT", "contract_rejected"),
+        ("REQUEST_EXTENSION", "contract_rejected"),
+        ("STREAM_CLOSED", "contract_rejected"),
+        ("MALFORMED_RESPONSE", "contract_rejected"),
+        ("ABORTED", "unknown"),
+    ],
+)
+def test_classify_official_dsh_terminal_codes(code: str, expected: str) -> None:
+    reason = {
+        "kind": "error",
+        "error": {"code": code, "message": "provider-controlled detail"},
+    }
+    assert host_failure_map.classify_dsh_terminal_reason(reason) == expected
+
+
+def test_server_code_without_status_does_not_need_prose_fallback() -> None:
+    reason = {
+        "kind": "error",
+        "error": {
+            "code": "SERVER",
+            "message": "selected model is at capacity",
+        },
+    }
+    assert (
+        host_failure_map.classify_dsh_terminal_reason(reason)
+        == "provider_overloaded"
+    )
+
+
+def test_classify_unknown_structured_code_never_falls_back_to_prose() -> None:
+    class _UnknownCode(Exception):
+        code = "mystery_condition"
+
+    exc = _UnknownCode("rate limit exceeded while the model is at capacity")
+    assert host_failure_map.classify_dsh_failure(exc) == "unknown"
+
+
+def test_classify_dsh_failure_folds_conflicting_prose_closed() -> None:
+    exc = RuntimeError("rate limit reached while the model is at capacity")
+    assert host_failure_map.classify_dsh_failure(exc) == "unknown"
+
+
+def test_run_dsh_host_returns_the_typed_result_in_process(tmp_path: Path) -> None:
+    runner = Path(__file__).parent / "dsh_goal_mode_fake_runner.py"
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path, dsh_runner=runner)
+    result = turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert result["schema_version"] == dsh_goal_mode.LOOPX_TURN_RESULT_SCHEMA
+    assert result["result_kind"] == "validated_progress"
+    assert result["completed_phases"] == list(dsh_goal_mode.COMPLETED_PHASES)
+    assert (tmp_path / ".local" / ".dsh-sessions").is_dir()
+
+
+def test_run_dsh_host_maps_terminal_provider_failure_without_an_exception(
+    tmp_path: Path,
+) -> None:
+    # The SDK reports provider failures as RunResult(finish_reason="error"),
+    # not as a raised exception; the adapter must still surface a typed kind.
+    runner = Path(__file__).parent / "dsh_goal_mode_capacity_runner.py"
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path, dsh_runner=runner)
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert excinfo.value.reason == "dsh_execution_failed"
+    assert excinfo.value.failure_kind == "provider_capacity"
+    record = build_host_failure_record(excinfo.value.failure_kind, attempt=1)
+    assert record["retryable"] is True
+    assert record["retry"]["backoff_seconds"] == 30
+    assert "selected model is at capacity" not in json.dumps(record)
+    assert "selected model is at capacity" not in str(excinfo.value)
+
+
+def test_run_dsh_host_maps_official_transport_terminal_failure(
+    tmp_path: Path,
+) -> None:
+    runner = Path(__file__).parent / "dsh_goal_mode_transport_runner.py"
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path, dsh_runner=runner)
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert excinfo.value.failure_kind == "transport_lost"
+    record = build_host_failure_record(excinfo.value.failure_kind, attempt=1)
+    assert record["retryable"] is True
+    assert record["retry"]["backoff_seconds"] == 10
+
+
+def test_run_dsh_host_maps_raised_capacity_prose_to_a_typed_retryable_kind(
+    tmp_path: Path,
+) -> None:
+    runner = Path(__file__).parent / "dsh_goal_mode_raising_runner.py"
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path, dsh_runner=runner)
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert excinfo.value.failure_kind == "provider_capacity"
+    assert (
+        build_host_failure_record("provider_capacity", attempt=1)["retryable"]
+        is True
+    )
+
+
+def test_build_sdk_config_targets_the_current_sdk_surface(tmp_path: Path) -> None:
+    dsh_home = tmp_path / "dsh-home"
+    cordis = tmp_path / "config" / ".." / "cordis.yml"
+    config = turn_host_adapter.build_sdk_config(
+        provider="deepseek-official",
+        model="deepseek-v4-flash",
+        workspace=tmp_path,
+        dsh_home=dsh_home,
+        max_tokens=1024,
+        cordis=cordis,
+        runtime_bin="/opt/dsh/bin/dsh",
+        request_timeout_seconds=90.0,
+    )
+    assert set(config) <= {
+        "provider",
+        "model",
+        "cwd",
+        "dsh_home",
+        "max_tokens",
+        "patches",
+        "dsh_bin",
+        "request_timeout_seconds",
+    }
+    assert config["dsh_home"] == str(dsh_home)
+    assert config["dsh_bin"] == "/opt/dsh/bin/dsh"
+    assert config["patches"] == (str(cordis.expanduser().resolve()),)
+    for legacy_field in ("session_root", "cordis", "runtime_bin"):
+        assert legacy_field not in config
+
+
+def test_dsh_home_resolution_prefers_config_then_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    configured = tmp_path / "configured-home"
+    environment = tmp_path / "environment-home"
+    monkeypatch.setenv("DSH_HOME", str(environment))
+
+    assert turn_host_adapter._resolve_dsh_home(workspace, configured) == configured
+    assert turn_host_adapter._resolve_dsh_home(workspace, None) == environment
+
+    monkeypatch.delenv("DSH_HOME")
+    assert turn_host_adapter._resolve_dsh_home(workspace, None) == (
+        workspace / ".local" / ".dsh-sessions"
+    )
+
+
+def test_terminal_error_reason_extraction() -> None:
+    success = {"final_response": "{}", "finish_reason": "stop", "events": []}
+    assert turn_host_adapter.terminal_error_reason(success) is None
+    bare_error = {"final_response": "", "finish_reason": "error", "events": []}
+    assert turn_host_adapter.terminal_error_reason(bare_error) == {"kind": "error"}
+    contradictory = {
+        "final_response": "",
+        "finish_reason": "error",
+        "events": [
+            {
+                "type": "turn/end",
+                "data": {"reason": {"kind": "stop", "status": 200}},
+            }
+        ],
+    }
+    with pytest.raises(turn_host_adapter.DshHostResultError):
+        turn_host_adapter.normalize_runner_outcome(contradictory)
+    assert turn_host_adapter.normalize_runner_outcome("just text") == {
+        "final_response": "just text",
+        "finish_reason": None,
+        "events": [],
+    }
+
+    sdk_result = SimpleNamespace(
+        final_response='{"result_kind":"wait"}',
+        finish_reason="completed",
+        events=[
+            {
+                "type": "turn/end",
+                "data": {"reason": {"kind": "completed"}},
+            }
+        ],
+    )
+    normalized = turn_host_adapter.normalize_runner_outcome(sdk_result)
+    assert normalized["finish_reason"] == "completed"
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        {},
+        {"final_response": 42, "finish_reason": "completed", "events": []},
+        {"final_response": "{}", "finish_reason": 42, "events": []},
+        {"final_response": "{}", "finish_reason": None, "events": "bad"},
+        {"final_response": "{}", "finish_reason": "error", "events": [None]},
+        {
+            "final_response": "{}",
+            "finish_reason": "error",
+            "events": [{"type": "turn/end", "data": {}}],
+        },
+        {
+            "final_response": "{}",
+            "finish_reason": "error",
+            "events": [
+                {"type": "turn/end", "data": {"reason": {"kind": 42}}}
+            ],
+        },
+    ],
+)
+def test_normalize_runner_outcome_rejects_invalid_shapes(outcome: object) -> None:
+    with pytest.raises(turn_host_adapter.DshHostResultError):
+        turn_host_adapter.normalize_runner_outcome(outcome)
+
+
+def test_run_dsh_host_rejects_untyped_requests_as_contract_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path)
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host({"schema_version": "nope"}, config=config)
+    assert excinfo.value.failure_kind == "contract_rejected"
+
+    tampered = _signed_request()
+    tampered["turn_envelope"]["action"]["primary_action"] = "tampered"
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(tampered, config=config)
+    assert excinfo.value.failure_kind == "contract_rejected"
+
+    monkeypatch.setattr(turn_host_adapter, "run_dsh_turn", lambda **_kwargs: {})
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert excinfo.value.reason == "dsh_host_result_rejected"
+    assert excinfo.value.failure_kind == "contract_rejected"
+
+    monkeypatch.setattr(
+        turn_host_adapter,
+        "run_dsh_turn",
+        lambda **_kwargs: '{"result_kind":"wait"}',
+    )
+
+    def _raise_result_shape_error(*_args: object, **_kwargs: object) -> dict:
+        raise RuntimeError("result shaping failed")
+
+    monkeypatch.setattr(turn_host_adapter, "build_result", _raise_result_shape_error)
+    with pytest.raises(BuiltInHostError) as excinfo:
+        turn_host_adapter.run_dsh_host(_signed_request(), config=config)
+    assert excinfo.value.reason == "dsh_host_result_rejected"
+    assert excinfo.value.failure_kind == "contract_rejected"
+
+
 def test_legacy_launcher_runs_the_same_contract() -> None:
     runner = Path(__file__).parent / "dsh_goal_mode_fake_runner.py"
     completed = subprocess.run(
@@ -237,3 +580,27 @@ def test_legacy_launcher_runs_the_same_contract() -> None:
     result = json.loads(completed.stdout)
     assert result["schema_version"] == dsh_goal_mode.LOOPX_TURN_RESULT_SCHEMA
     assert result["result_kind"] == "validated_progress"
+
+
+def test_subprocess_terminal_error_keeps_the_legacy_wait_contract() -> None:
+    runner = Path(__file__).parent / "dsh_goal_mode_capacity_runner.py"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.dsh_goal_mode",
+            "--dsh-runner",
+            str(runner),
+        ],
+        input=json.dumps(_signed_request()),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["result_kind"] == "wait"
+    assert result["classification"] == "no_typed_host_result"
+    assert "dsh execution failed" not in completed.stderr

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -281,6 +281,7 @@ def test_deepseek_harness_is_an_exact_host_type_with_external_loop_activation() 
     assert packet["host_surface"] == "deepseek_harness_automation_loop", packet
     assert packet["activation_method"] == "external_loop_driver", packet
     assert "--runtime-profile generic_cli" in packet["commands"]["heartbeat_prompt"], packet
+    assert "--host dsh" in packet["entry_command_hint"], packet
     assert "loopx.dsh_goal_mode" in packet["entry_command_hint"], packet
     # The historical launcher stays a documented compatibility path.
     assert "scripts/dsh_turn_host_adapter.py" in packet["entry_command_hint"], packet

--- a/tests/test_host_parity_smoke.py
+++ b/tests/test_host_parity_smoke.py
@@ -158,8 +158,13 @@ class TestSchedulerBindings:
 
 class TestTurnHostIdentities:
     def test_supported_hosts(self):
-        assert SUPPORTED_HOSTS == {"codex-cli", "claude-code", "generic-cli"}
-        assert set(SUPPORTED_TURN_HOST_IDENTITIES) == SUPPORTED_HOSTS
+        assert SUPPORTED_HOSTS == {"codex-cli", "claude-code", "dsh", "generic-cli"}
+        assert set(SUPPORTED_TURN_HOST_IDENTITIES) == {
+            "codex-cli",
+            "claude-code",
+            "generic-cli",
+        }
+        assert "dsh" not in SUPPORTED_TURN_HOST_IDENTITIES
 
     def test_execution_modes(self):
         assert SUPPORTED_EXECUTION_MODES == {"interactive-visible",

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -124,6 +124,28 @@ def test_turn_plan_projects_ready_route_without_side_effects() -> None:
     assert payload["boundary"]["read_only"] is True
 
 
+def test_dsh_turn_plan_uses_the_headless_outer_controller_context() -> None:
+    payload = build_loopx_turn_plan(
+        _envelope(),
+        host="dsh",
+        execution_mode="isolated-headless",
+    )
+
+    assert payload["ok"] is True
+    assert payload["route"]["kind"] == LoopXTurnRoute.READY_FOR_HOST.value
+    assert payload["host"]["kind"] == "dsh"
+    assert payload["host"]["explicit_isolation"] is True
+    assert payload["scheduler_execution_context"] == {
+        "schema_version": "scheduler_execution_context_v0",
+        "host_surface": "generic_cli",
+        "scheduler_owner": "outer_controller",
+        "execution_mode": "isolated_headless",
+        "source": "loopx_turn",
+        "valid": True,
+        "codex_app_applicability": "not_applicable",
+    }
+
+
 def _adaptive_envelope() -> dict[str, object]:
     envelope = _envelope()
     envelope["task_orchestration_contract"] = {


### PR DESCRIPTION
## Summary

- add an explicit, opt-in `loopx turn run-once --host dsh` in-process host
- preserve terminal DeepSeek Harness `RunResult` failures and translate them
  into the existing typed Turn host-failure contract
- qualify the exact SDK surface, retain the generic CLI rollback path, and
  document the headless/default-off authority boundary

## Issue Or Task

- Closes #3821
- Contributor task ID: #3821

## Validation

- [x] `python3 -m py_compile` for every changed Python file (premerge gate)
- [x] `loopx check --scan-path loopx/ --scan-path tests/ --scan-path examples/ --scan-path docs/`
- [x] `python -m pytest -q -n 2 --cov=loopx --cov-report=term --cov-fail-under=19.6` — 5104 passed, 12 skipped, 71.09% coverage
- [x] `npm run typecheck:control-plane` and `npm run test:control-plane`
- [x] repository ruff and configured mypy checks; isolated strict mypy for the DSH adapter
- [x] `loopx canary premerge --from-git-diff --git-diff-base official/main` — 18/18 selected checks passed, no warnings or manual holds
- [x] focused adapter, generic CLI, built-in host, host-mode planning, and CLI-output-budget smokes
- [x] real `deepseek-harness-sdk==0.1.2a3` E2E for both `--host generic-cli` and `--host dsh`

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [x] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: #3821

## Behavior And Contract

The built-in host receives one signed, bounded Turn request and returns one
typed result or typed failure. LoopX remains the sole authority for independent
validation, state writeback, quota settlement, retry attempts, and scheduler
policy.

Failure classification is fail closed and ordered by signal authority:

1. structured provider code;
2. HTTP status when no provider code is present;
3. exception type when no structured signal is present;
4. bounded diagnostic fallback.

Unknown structured codes block lower-tier prose, and conflicting signals in
the same tier reduce to `unknown`. Terminal SDK failures are read from
`finish_reason` and the last `turn/end.data.reason`, not only Python
exceptions.

The SDK dependency is intentionally pinned to `0.1.2a3`. The implementation
uses its qualified `dsh_home`, `dsh_bin`, `patches`, and timeout fields; patch
paths are normalized before launch. The official `SERVER` code maps to
`provider_overloaded`, while the provider-specific capacity fixture maps to
`provider_capacity`.

## Compatibility And Non-goals

- The existing generic CLI adapter remains available as a compatibility and
  rollback path.
- `dsh` maps to a headless `generic_cli` execution surface owned by an outer
  controller. It does not become a visible TUI host identity.
- This PR does not add a managed supervisor, timer, resident scheduler, second
  retry ledger, Pi parity, or a public LoopX Host Session Binding/resume
  guarantee.

## Future-facing Scope Pass

Applied: the change narrows visible host identities to registered visible
connectors, keeps the new adapter API internal to its owning module, validates
the SDK result shape at the boundary, and removes duplicate failure authority.

Deferred: LoopX-side session binding and a managed outer supervisor require
separate persisted-lifecycle contracts and are not inferred from the DSH
private session layout.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
