### PR TITLE
fix(authority): remove status reverse import

### DIFF
--- a/loopx/control_plane/coordination/local_authority_shadow_adapter.py
+++ b/loopx/control_plane/coordination/local_authority_shadow_adapter.py
@@ -686,12 +686,17 @@ def _read_state_text(path: Path) -> str:
 
 
 def _event_present(sources: _GoalSources, event_id: str) -> bool:
+    from ..goals.active_state_event_projection import state_event_log_candidates
+    from ..goals.path_resolution import resolve_goal_local_path
     from ...event_sourced_state import AppendOnlyStateEventStore
-    from ...status import state_event_log_candidates
 
     if sources.goal is None:
         return False
-    for candidate in state_event_log_candidates(sources.goal, state_path=sources.state_path):
+    for candidate in state_event_log_candidates(
+        sources.goal,
+        state_path=sources.state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+    ):
         if not candidate.exists():
             continue
         for event in AppendOnlyStateEventStore(candidate).load():


### PR DESCRIPTION
## Summary

- replace the authority-shadow adapter reverse import from top-level `loopx.status` with the existing goals-owned event-log candidate primitive;
- inject the same goal-local path resolver explicitly, preserving event-log discovery semantics;
- restore the existing Todo read-model bounded-context smoke on the exact current `main`.

## Regression evidence

On exact official `main` `bf5dda59c`, `examples/control_plane/todo-readmodel-boundary-smoke.py` fails with:

`loopx/control_plane/coordination/local_authority_shadow_adapter.py:690 from ...status import`

The smoke passes on this branch. The change keeps the adapter inside lower-level control-plane owners and does not alter authority, writer, outbox, or projection behavior.

## Validation

- `python examples/control_plane/todo-readmodel-boundary-smoke.py` — passed
- authority-shadow drain and runtime-shadow writer capture suites — 18 passed
- focused Ruff and `git diff --check` — passed
- `loopx check` public/private boundary scan — clean
- `loopx canary premerge --from-git-diff --git-diff-base official/main` — 12 selected checks passed, 0 failures, 0 manual holds

## Future-facing scope pass

Applied: reused the existing goals-owned primitive and dependency-injection boundary instead of adding another event-log resolver or compatibility wrapper. No broader module move is needed for this regression.