### PR TITLE
fix(review): align behavior disclosure contract

### DIFF
--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -433,7 +433,8 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "rule": (
                     "Default behavior changes in runtime or automatically loaded "
                     "instruction surfaces must be disclosed through renamed smokes, "
-                    "docs, or release notes. Flag silent changes that alter existing "
+                    "docs, or release notes. Flag silent behavior changes that alter "
+                    "existing "
                     "automation or ordinary agent behavior without naming the old and "
                     "new default."
                 ),


### PR DESCRIPTION
## Summary

- align the machine-readable behavior-disclosure rule with its required contract phrase, `silent behavior changes`;
- preserve the existing obligation and scope while restoring the current required test suite.

## Why

Official `main@5c56d3868` deterministically fails `test_execution_contract_owns_deep_review_requirements`: the test requires `silent behavior changes`, while the contract currently says `silent changes`. This was surfaced by the full required suite on #3936 and reproduces on a clean latest-main worktree.

The drift comes from `55dadee68` ("Harden instruction-surface review risk"), which reworded the rule to `Flag silent changes that alter existing automation or ordinary agent behavior` without updating the test. Restoring the phrase in the rule text rather than loosening the test keeps `silent behavior changes` as the stable contract phrase the test guards, while preserving the broadened scope introduced by that commit.

Because required `pytest` runs on the merge commit with `main`, every open PR currently inherits this failure (#3935, #3936, #3942 at the time of writing); they will re-run once this lands.

The separate 1 ms host-loop timing failure from that run does not reproduce: all five bounded-wait parameters pass on the same clean snapshot.

## Validation

- `pytest -q tests/capabilities/test_pr_review_contract.py tests/test_pr_review_github_scan.py` - 15 passed
- `pytest -q tests/test_host_loop_runtime_parity.py -k shell_worker_and_pi_share_bounded_wait_plan` - 5 passed
- `loopx canary premerge --from-git-diff --git-diff-base refs/remotes/official/main` - 1/1 passed
- Ruff and `git diff --check` - passed

## Future-facing scope pass

No companion refactor is needed: the implementation and test already share the correct owner; this only repairs their exact public contract wording.
