### PR TITLE
fix(smokes): cover new goal configuration catalog features

### DIFF
--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -208,6 +208,7 @@ def main() -> int:
         assert catalog["disclosure_policy"]["first_run_configuration_required"] is False
         features = {item["feature_id"]: item for item in catalog["features"]}
         assert set(features) == {
+            "local_authority_shadow",
             "multi_subagent",
             "peer_task_coordination",
             "explore_graph",
@@ -216,7 +217,26 @@ def main() -> int:
             "reward_memory",
             "lark_event_inbox",
             "lark_kanban_heartbeat_sync",
+            "periodic_report",
         }
+        assert features["local_authority_shadow"]["availability"] == "experimental_opt_in"
+        assert features["local_authority_shadow"]["default"] == {"enabled": False}
+        assert features["local_authority_shadow"]["current"] == {
+            "enabled": False,
+            "mode": None,
+            "status": "disabled",
+        }
+        assert "--local-authority-shadow-file" in features[
+            "local_authority_shadow"
+        ]["commands"]["preview_enable"]
+        assert "--execute" not in features["local_authority_shadow"]["commands"]["preview_enable"]
+        assert "--execute" in features["local_authority_shadow"]["commands"]["apply_enable"]
+        assert features["periodic_report"]["availability"] == "supported_explicit_override"
+        assert features["periodic_report"]["default"] == {"enabled": False, "timezone": "UTC"}
+        # A Goal without an explicit override follows the machine default, so the
+        # catalog reports no Goal-scoped current value instead of a synthetic one.
+        assert "current" not in features["periodic_report"], features["periodic_report"]
+        assert set(features["periodic_report"]["commands"]) == {"verify"}
         assert features["multi_subagent"]["current"]["enabled"] is True
         assert features["multi_subagent"]["required_inputs"] == {}
         assert "--allowed-domain" not in features["multi_subagent"]["commands"][


### PR DESCRIPTION
## Summary

- `examples/project/configure-goal-smoke.py` asserted an exact default-off feature set that no longer matches the goal configuration catalog: `local_authority_shadow` (Stage 2C, #3882) and `periodic_report` (#3865 / #3910) are now reported, so the smoke fails on shard 3 of `Full Public Smokes` on every `main` head since `343b5f972`.
- Extend the expected set and assert the never-opted-in defaults from the feature semantics, not from the observed output: `local_authority_shadow` is `experimental_opt_in` with `current == {"enabled": false, "mode": null, "status": "disabled"}` and a preview/apply `--execute` contract; `periodic_report` is `supported_explicit_override`, default `{"enabled": false, "timezone": "UTC"}`, and intentionally carries no `current` key while the Goal has no override (the configuration UI already treats it as optional).
- Smoke-only change. It guards the shipped default-off disclosure of two real capabilities; no runtime, CLI, or default behavior changes.

Companion baseline PRs for the other shard failures: #3943 (concise help and manpage parity) and #3944 (`todo.py` owner extraction). Each is independent and can merge in any order.

## Issue Or Task

- Closes #
- Contributor task ID: baseline repair for the red `Full Public Smokes` workflow on `main`

## Validation

- [x] `python3 -m py_compile examples/project/configure-goal-smoke.py`
- [x] `python3 examples/project/configure-goal-smoke.py` -> `configure-goal-smoke ok`
- [x] `python3 examples/run-smokes.py --script examples/project/configure-goal-smoke.py` -> ok
- [x] `loopx canary premerge --from-git-diff --git-diff-base <official main>` -> 13/13 selected checks passed, 0 manual holds
- [x] `git diff --check` clean; commit carries the DCO trailer

## Type of Change

- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)

## Technical Direction

- [x] Core control-plane hardening

- Target base branch: `main`
- Direction tracker or promotion unit: `Full Public Smokes` baseline

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
